### PR TITLE
swiftlintが機能していなかったので修正

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -5,14 +5,10 @@ excluded:
 
 disabled_rules:
   - line_length
-  - function_body_length
   - function_parameter_count
-  - file_length
   - force_cast
   - force_try
   - nesting
-  - valid_docs
-  - trailing_whitespace
   - superfluous_disable_command
 
 opt_in_rules:
@@ -26,7 +22,6 @@ opt_in_rules:
   - first_where
   - last_where
   - literal_expression_end_indentation
-  - perator_usage_whitespace
   - private_action
   - sorted_first_last
   - unneeded_parentheses_in_closure_argument
@@ -42,7 +37,7 @@ opt_in_rules:
   - static_operator
   - toggle_bool
   - unused_import
-  - unused_private_declaration
+  - unused_declaration
 
 trailing_whitespace:
   ignores_empty_lines: true # 改行時にxcodeが自動でインデントタブ入れるので許容する
@@ -54,8 +49,10 @@ type_name:
     warning: 45
     error: 60
   excluded:
-    - X # coordinator
-    - Y # coordinator
+    - Samidare_iOSApp
+    - Samidare_iOSUITestsLaunchTests
+    - Samidare_iOSTests
+    - Samidare_iOSUITests
 
 trailing_comma:
   # リテラル表記を要素毎に改行している場合、最後の要素に必ずcommaを付ける

--- a/Samidare-iOS/ApplicationModel/Repository/Realm/Question/AppConfigRepository.swift
+++ b/Samidare-iOS/ApplicationModel/Repository/Realm/Question/AppConfigRepository.swift
@@ -16,7 +16,7 @@ protocol AppConfigRepository {
 class AppConfigRepositoryImpl: AppConfigRepository {
     func get() throws -> AppConfig {
         let realm = try Realm()
-        //TODO: 文言管理を行う
+        // TODO: 文言管理を行う
         guard let results = realm.objects(AppConfigRealmObject.self).first else {
             return AppConfig(gameType: .init(name: "インタビュー"),
                              questionGroup: .init(name: "デフォルト"),
@@ -29,10 +29,7 @@ class AppConfigRepositoryImpl: AppConfigRepository {
     
     func update(_ appConfig: AppConfig) throws {
         let realm = try Realm()
-        let appConfigObject = AppConfigRealmObject(value: ["id": appConfig.id.uuidString,
-                                                           "gameType": appConfig.gameType.name,
-                                                           "questionGroup": appConfig.questionGroup.name,
-                                                           "time": appConfig.time])
+        let appConfigObject = AppConfigRealmObject(value: ["id": appConfig.id.uuidString, "gameType": appConfig.gameType.name, "questionGroup": appConfig.questionGroup.name, "time": appConfig.time])
         try realm.write {
             realm.add(appConfigObject, update: .modified)
         }

--- a/Samidare-iOS/ApplicationModel/Repository/Realm/Question/QuestionGroupRepository.swift
+++ b/Samidare-iOS/ApplicationModel/Repository/Realm/Question/QuestionGroupRepository.swift
@@ -31,9 +31,7 @@ class QuestionGroupRepositoryImpl: QuestionGroupRepository {
     }
     
     func delete(_ questionGroup: QuestionGroup) throws {
-        //TODO: 実装
+        // TODO: 実装
         assert(true)
     }
-    
-    
 }

--- a/Samidare-iOS/ApplicationModel/Repository/Realm/Question/QuestionRepository.swift
+++ b/Samidare-iOS/ApplicationModel/Repository/Realm/Question/QuestionRepository.swift
@@ -48,7 +48,7 @@ class QuestionRepositoryImpl: QuestionRepository {
     }
     
     func delete(_ question: Question, of group: String) throws {
-        //TODO: 実装
+        // TODO: 実装
         assert(true)
     }
 }

--- a/Samidare-iOS/Samidare_iOSApp.swift
+++ b/Samidare-iOS/Samidare_iOSApp.swift
@@ -14,6 +14,7 @@ struct Samidare_iOSApp: App {
         FirebaseApp.configure()
         RealmConfig.configure()
     }
+    
     var body: some Scene {
         WindowGroup {
             ContentView()

--- a/Samidare-iOSTests/Samidare_iOSTests.swift
+++ b/Samidare-iOSTests/Samidare_iOSTests.swift
@@ -11,10 +11,12 @@ import XCTest
 class Samidare_iOSTests: XCTestCase {
 
     override func setUpWithError() throws {
+        super.setUpWithError()
         // Put setup code here. This method is called before the invocation of each test method in the class.
     }
 
     override func tearDownWithError() throws {
+        super.tearDownWithError()
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
 

--- a/Samidare-iOSUITests/Samidare_iOSUITests.swift
+++ b/Samidare-iOSUITests/Samidare_iOSUITests.swift
@@ -10,6 +10,7 @@ import XCTest
 class Samidare_iOSUITests: XCTestCase {
 
     override func setUpWithError() throws {
+        super.setUpWithError()
         // Put setup code here. This method is called before the invocation of each test method in the class.
 
         // In UI tests it is usually best to stop immediately when a failure occurs.
@@ -19,6 +20,7 @@ class Samidare_iOSUITests: XCTestCase {
     }
 
     override func tearDownWithError() throws {
+        super.tearDownWithError()
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
 

--- a/Samidare-iOSUITests/Samidare_iOSUITestsLaunchTests.swift
+++ b/Samidare-iOSUITests/Samidare_iOSUITestsLaunchTests.swift
@@ -14,6 +14,7 @@ class Samidare_iOSUITestsLaunchTests: XCTestCase {
     }
 
     override func setUpWithError() throws {
+        super.setUpWithError()
         continueAfterFailure = false
     }
 

--- a/project.yml
+++ b/project.yml
@@ -216,10 +216,15 @@ targets:
           fi
       - name: SwiftLint
         script: |
-          if mint list | grep -q 'SwiftLint'; then
+          if test -d /opt/homebrew/bin; then
+            PATH=/opt/homebrew/bin/:$PATH
+            echo "if通過"
+          fi
+
+          if which mint >/dev/null; then
             mint run swiftlint
           else
-            echo "SwiftLint does not exist, download from https://github.com/realm/SwiftLint"
+            echo "warning: Mint not installed, download from https://github.com/yonaskolb/Mint"
           fi
   Samidare-iOSTests:
     info:

--- a/project.yml
+++ b/project.yml
@@ -218,7 +218,6 @@ targets:
         script: |
           if test -d /opt/homebrew/bin; then
             PATH=/opt/homebrew/bin/:$PATH
-            echo "if通過"
           fi
 
           if which mint >/dev/null; then


### PR DESCRIPTION
## 概要
M1 MacだとHomeBrewでインストールしたMintのpathが違っていてscriptが正常に走っていなかったため修正を行なった

## 参考
- [M1 MacでSwiftLintが動かない](https://zenn.dev/muhiro12/articles/swiftlint-m1-issue)