### PR TITLE
グループ名編集機能実装

### DIFF
--- a/Samidare-iOS/GroupAdditionModule/GroupAdditionView.swift
+++ b/Samidare-iOS/GroupAdditionModule/GroupAdditionView.swift
@@ -50,7 +50,7 @@ struct GroupAdditionView<Repository: QuestionGroupRepositoryProtocol>: View {
                                 Button {
                                     presenter.didTapEditSwipeAction(editQuestionGroup: group)
                                 } label: {
-                                    Image(systemName: "pencil")
+                                    Text(L10n.Common.edit)
                                 }
                                 .tint(.yellow)
                             }
@@ -58,7 +58,7 @@ struct GroupAdditionView<Repository: QuestionGroupRepositoryProtocol>: View {
                                 Button(role: .destructive) {
                                     presenter.delete(group)
                                 } label: {
-                                    Text("削除")
+                                    Text(L10n.Common.delete)
                                 }
                             }
                         }

--- a/Samidare-iOS/GroupAdditionModule/GroupAdditionView.swift
+++ b/Samidare-iOS/GroupAdditionModule/GroupAdditionView.swift
@@ -17,7 +17,7 @@ struct GroupAdditionView<Repository: QuestionGroupRepositoryProtocol>: View {
     // swiftlint:disable closure_body_length
     var body: some View {
         ZStack {
-            TextFieldAlertView(text: $presenter.alertText,
+            TextFieldAlertView(text: $presenter.addAlertText,
                                isShowingAlert: $presenter.isShowingAddAlert,
                                placeholder: "",
                                isSecureTextEntry: false,
@@ -27,6 +27,16 @@ struct GroupAdditionView<Repository: QuestionGroupRepositoryProtocol>: View {
                                rightButtonTitle: L10n.Common.ok,
                                leftButtonAction: nil,
                                rightButtonAction: { presenter.addQuestionGroup() })
+            TextFieldAlertView(text: $presenter.editAlertText,
+                               isShowingAlert: $presenter.isShowingEditAlert,
+                               placeholder: "",
+                               isSecureTextEntry: false,
+                               title: L10n.Group.Addition.Update.Alert.title,
+                               message: L10n.Group.Addition.Update.Alert.message,
+                               leftButtonTitle: L10n.Common.cancel,
+                               rightButtonTitle: L10n.Common.ok,
+                               leftButtonAction: nil,
+                               rightButtonAction: { presenter.editQuestionGroupName() })
             List {
                 Section {
                     if let groups = self.presenter.groups {
@@ -36,10 +46,22 @@ struct GroupAdditionView<Repository: QuestionGroupRepositoryProtocol>: View {
                                     .font(.system(size: 17))
                                     .foregroundColor(Color.textBlack)
                             }
+                            .swipeActions(edge: .leading, allowsFullSwipe: false) {
+                                Button {
+                                    presenter.didTapEditSwipeAction(editQuestionGroup: group)
+                                } label: {
+                                    Image(systemName: "pencil")
+                                }
+                                .tint(.yellow)
+                            }
+                            .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                                Button(role: .destructive) {
+                                    presenter.delete(group)
+                                } label: {
+                                    Text("削除")
+                                }
+                            }
                         }
-                        .onDelete(perform: { indexSet in
-                            Task { presenter.deleteGroup(on: indexSet) }
-                        })
                     }
                 }
             }

--- a/Samidare-iOS/QuestionAdditionModule/QuestionAdditionPresenter.swift
+++ b/Samidare-iOS/QuestionAdditionModule/QuestionAdditionPresenter.swift
@@ -11,9 +11,10 @@ import Foundation
 @MainActor
 class QuestionAdditionPresenter<Repository: QuestionRepositoryProtocol>: ObservableObject {
     private let interactor: QuestionAdditionInteractor<Repository>
-    private let group: QuestionGroup
     
     private var questionToUpdate: Question?
+    
+    let group: QuestionGroup
     
     @Published private(set) var questions: [Question]?
     @Published var isShowingAddAlert = false

--- a/Samidare-iOS/QuestionAdditionModule/QuestionAdditionView.swift
+++ b/Samidare-iOS/QuestionAdditionModule/QuestionAdditionView.swift
@@ -50,7 +50,7 @@ struct QuestionAdditionView<Repository: QuestionRepositoryProtocol>: View {
                     })
                 }
             }
-            .navigationTitle(L10n.Question.Addition.title)
+            .navigationTitle(presenter.group.name)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {

--- a/Samidare-iOS/SupportingFiles/en.lproj/Localizable.strings
+++ b/Samidare-iOS/SupportingFiles/en.lproj/Localizable.strings
@@ -45,6 +45,8 @@
 "Group.Addition.Title" = "質問グループ";
 "Group.Addition.Alert.Title" = "質問グループ名";
 "Group.Addition.Alert.Message" = "追加する質問グループ名を入力してください。";
+"Group.Addition.Update.Alert.Title" = "質問グループ名更新";
+"Group.Addition.Update.Alert.Message" = "更新する質問グループ名を入力してください。";
 
 // 質問追加画面
 "Question.Addition.Title" = "質問";

--- a/Samidare-iOS/SupportingFiles/en.lproj/Localizable.strings
+++ b/Samidare-iOS/SupportingFiles/en.lproj/Localizable.strings
@@ -11,6 +11,8 @@
 "Common.OK" = "OK";
 "Common.cancel" = "Cancel";
 "Common.Add" = "Add ";
+"Common.delete" = "Delete";
+"Common.edit" = "Edit";
 
 // Tab画面
 "Tab.Question" = "Question";

--- a/Samidare-iOS/SupportingFiles/ja.lproj/Localizable.strings
+++ b/Samidare-iOS/SupportingFiles/ja.lproj/Localizable.strings
@@ -44,6 +44,8 @@
 "Group.Addition.Title" = "質問グループ";
 "Group.Addition.Alert.Title" = "質問グループ名";
 "Group.Addition.Alert.Message" = "追加する質問グループ名を入力してください。";
+"Group.Addition.Update.Alert.Title" = "質問グループ名更新";
+"Group.Addition.Update.Alert.Message" = "更新する質問グループ名を入力してください。";
 
 // 質問追加画面
 "Question.Addition.Title" = "質問";

--- a/Samidare-iOS/SupportingFiles/ja.lproj/Localizable.strings
+++ b/Samidare-iOS/SupportingFiles/ja.lproj/Localizable.strings
@@ -11,6 +11,8 @@
 "Common.OK" = "OK";
 "Common.cancel" = "Cancel";
 "Common.Add" = "追加";
+"Common.delete" = "削除";
+"Common.edit" = "編集";
 
 // Tab画面
 "Tab.Question" = "質問";

--- a/Samidare-iOSTests/GroupAddition/GroupAdditionPresenterTests.swift
+++ b/Samidare-iOSTests/GroupAddition/GroupAdditionPresenterTests.swift
@@ -58,6 +58,16 @@ class GroupAdditionPresenterTests: XCTestCase {
         XCTAssertTrue(isShowingAddAlert)
     }
     
+    func testDidTapEditSwipeAction() async {
+        let questionGroup = QuestionGroup(name: "DidTapEditSwipeAction Test")
+        let presenter = await GroupAdditionPresenter<QuestionGroupRepositoryProtocolMock>(interactor: .init(), router: .init())
+        await presenter.didTapEditSwipeAction(editQuestionGroup: questionGroup)
+        let editAlertText = await presenter.editAlertText
+        let isShowingEditAlert = await presenter.isShowingEditAlert
+        XCTAssertEqual(editAlertText, questionGroup.name)
+        XCTAssertTrue(isShowingEditAlert)
+    }
+    
     func testDeleteGroup() async {
         let presenter = await GroupAdditionPresenter<QuestionGroupRepositoryProtocolMock>(interactor: .init(), router: .init())
         var groups = await presenter.groups

--- a/Samidare-iOSTests/GroupAddition/GroupAdditionPresenterTests.swift
+++ b/Samidare-iOSTests/GroupAddition/GroupAdditionPresenterTests.swift
@@ -60,16 +60,14 @@ class GroupAdditionPresenterTests: XCTestCase {
     
     func testDeleteGroup() async {
         let presenter = await GroupAdditionPresenter<QuestionGroupRepositoryProtocolMock>(interactor: .init(), router: .init())
-        QuestionGroupRepositoryProtocolMock.deleteHandler = { questionGroup in
-            XCTAssertEqual(questionGroup.name, "デフォルト（テスト）")
-        }
         var groups = await presenter.groups
         XCTAssertFalse(groups!.isEmpty)
         let deleteCallCountBefore = QuestionGroupRepositoryProtocolMock.deleteCallCount
-        await presenter.deleteGroup(on: .init(integer: 0))
+        let getCallCountBefore = QuestionGroupRepositoryProtocolMock.getCallCount
+        await presenter.delete(.init(name: "テスト"))
         groups = await presenter.groups
-        XCTAssertTrue(groups!.isEmpty)
         XCTAssertEqual(QuestionGroupRepositoryProtocolMock.deleteCallCount, deleteCallCountBefore + 1)
+        XCTAssertEqual(QuestionGroupRepositoryProtocolMock.getCallCount, getCallCountBefore + 1)
     }
     
     func testQuestionAdditionLinkBuilder() async {


### PR DESCRIPTION
## 概要
質問グループを編集する機能を実装

## issue
fix #75 

## UI
### 編集ボタン表示
<img src="https://user-images.githubusercontent.com/20432404/187016550-bd2ae737-e1d6-4509-89a9-67867c889205.png" width=250 heigh=500>
### 編集アラート表示
<img src="https://user-images.githubusercontent.com/20432404/187016551-428a7a19-b1cd-4634-8cfa-596215107779.png" width=250 heigh=500>