### PR TITLE
表示グループ設定の切り替えができないバグの修正

### DIFF
--- a/Samidare-iOS/AppConfigSelectionModule/AppConfigSelectionInteractor.swift
+++ b/Samidare-iOS/AppConfigSelectionModule/AppConfigSelectionInteractor.swift
@@ -20,9 +20,9 @@ class AppConfigSelectionInteractor<AppConfigRepository: AppConfigRepositoryProto
         AppConfigRepository.get().questionGroup
     }
     
-    func update(questionGroup: String) throws {
+    func update(questionGroup: QuestionGroup) throws {
         let currentAppConfig = AppConfigRepository.get()
-        let updateAppConfig = AppConfig(id: currentAppConfig.id, questionGroup: .init(name: questionGroup), time: currentAppConfig.time)
+        let updateAppConfig = AppConfig(id: currentAppConfig.id, questionGroup: questionGroup, time: currentAppConfig.time)
         try AppConfigRepository.update(updateAppConfig)
     }
     

--- a/Samidare-iOS/AppConfigSelectionModule/AppConfigSelectionPresenter.swift
+++ b/Samidare-iOS/AppConfigSelectionModule/AppConfigSelectionPresenter.swift
@@ -33,7 +33,7 @@ class AppConfigSelectionPresenter<AppConfigRepository: AppConfigRepositoryProtoc
         questionGroups = interactor.questionGroups()
     }
     
-    func update(questionGroup: String) {
+    func update(questionGroup: QuestionGroup) {
         guard type == .questionGroup else { return }
         do {
             try interactor.update(questionGroup: questionGroup)

--- a/Samidare-iOS/AppConfigSelectionModule/AppConfigSelectionView.swift
+++ b/Samidare-iOS/AppConfigSelectionModule/AppConfigSelectionView.swift
@@ -25,7 +25,7 @@ struct AppConfigSelectionView<AppConfigRepository: AppConfigRepositoryProtocol, 
                         ForEach(questionGroups) { group in
                             ListRow(title: group.name, isSelected: presenter.isSelectedQuestionGroup(questionGroup: group))
                                 .onTapGesture {
-                                    presenter.update(questionGroup: group.name)
+                                    presenter.update(questionGroup: group)
                                 }
                         }
                     }

--- a/Samidare-iOSTests/AppConfigSelection/AppConfigSelectionInteractorTests.swift
+++ b/Samidare-iOSTests/AppConfigSelection/AppConfigSelectionInteractorTests.swift
@@ -42,10 +42,10 @@ class AppConfigSelectionInteractorTests: XCTestCase {
     func testUpdateQuestionGroup() {
         AppConfigRepositoryProtocolMock.updateHandler = { updateAppConfig in
             XCTAssertEqual(self.appConfig.id, updateAppConfig.id)
-            XCTAssertNotEqual(self.appConfig.questionGroup.name, updateAppConfig.questionGroup.name)
+            XCTAssertNotEqual(self.appConfig.questionGroup, updateAppConfig.questionGroup)
             XCTAssertEqual(updateAppConfig.questionGroup.name, "更新Test")
         }
-        try! interactor.update(questionGroup: "更新Test")
+        try! interactor.update(questionGroup: .init(name: "更新Test"))
     }
     
     func testUpdateGameTime() {

--- a/Samidare-iOSTests/AppConfigSelection/AppConfigSelectionPresenterTests.swift
+++ b/Samidare-iOSTests/AppConfigSelection/AppConfigSelectionPresenterTests.swift
@@ -71,16 +71,17 @@ class AppConfigSelectionPresenterTests: XCTestCase {
     }
     
     func testUpdateQuestionGroup() async {
+        let updateQuestionGroup = QuestionGroup(name: "Update Test")
         let presenter = await AppConfigSelectionPresenter<AppConfigRepositoryProtocolMock, QuestionGroupRepositoryProtocolMock>(interactor: .init(), type: .questionGroup)
         let questionGroup = await presenter.questionGroups![0]
         // initで取得した値か確認
         XCTAssertEqual(questionGroup, self.questionGroup)
         AppConfigRepositoryProtocolMock.updateHandler = { appConfig in
             // Presenterのupdateの引数の値で更新されているか確認
-            XCTAssertEqual(appConfig.questionGroup.name, "Update Test")
+            XCTAssertEqual(appConfig.questionGroup, updateQuestionGroup)
         }
         let beforequestionGroupsCount = QuestionGroupRepositoryProtocolMock.getCallCount
-        await presenter.update(questionGroup: "Update Test")
+        await presenter.update(questionGroup: updateQuestionGroup)
         // fetchQuestionGroupsを呼んでいるか確認
         XCTAssertEqual(beforequestionGroupsCount + 1, QuestionGroupRepositoryProtocolMock.getCallCount)
     }


### PR DESCRIPTION
## 概要
表示グループ設定の変更が行えなかったバグの修正

## 原因
InteractorにStringしか渡してなくてQuestionGroupをInteractorで生成していたため、idが初期化されてしまっていた。
そのためRepositoryのfilterで弾かれてしまった

## 対応
StringではなくてQuestionGroupオブジェクトを渡すように修正