### PR TITLE
FirebaseAnalyticsとFirebaseCrashlytics実装

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -54,7 +54,7 @@ type_name:
 
 trailing_comma:
   # リテラル表記を要素毎に改行している場合、最後の要素に必ずcommaを付ける
-  mandatory_comma: true
+  mandatory_comma: false
 
 identifier_name:
   min_length:

--- a/Samidare-iOS/AppConfigSelectionModule/AppConfigSelectionPresenter.swift
+++ b/Samidare-iOS/AppConfigSelectionModule/AppConfigSelectionPresenter.swift
@@ -34,6 +34,7 @@ class AppConfigSelectionPresenter<AppConfigRepository: AppConfigRepositoryProtoc
     }
     
     func update(questionGroup: String) {
+        FirebaseAnalyticsConfig.sendEventLog(eventType: .changeQuestionGroup)
         guard type == .questionGroup else { return }
         do {
             try interactor.update(questionGroup: questionGroup)
@@ -44,6 +45,7 @@ class AppConfigSelectionPresenter<AppConfigRepository: AppConfigRepositoryProtoc
     }
     
     func update(gameTime: Int) {
+        FirebaseAnalyticsConfig.sendEventLog(eventType: .changeQuestionTime)
         guard type == .gameTime else { return }
         do {
             try interactor.update(gameTime: gameTime)

--- a/Samidare-iOS/AppConfigSelectionModule/AppConfigSelectionView.swift
+++ b/Samidare-iOS/AppConfigSelectionModule/AppConfigSelectionView.swift
@@ -46,6 +46,7 @@ struct AppConfigSelectionView<AppConfigRepository: AppConfigRepositoryProtocol, 
             }
             .onAppear {
                 presenter.fetchQuestionGroups()
+                FirebaseAnalyticsConfig.sendScreenViewLog(screenName: "\(AppConfigSelectionView.self)")
             }
         }
         .navigationTitle(L10n.App.Config.Selection.Question.Group.title)

--- a/Samidare-iOS/ApplicationModel/Model/Firebase/FirebaseAnalyticsConfig.swift
+++ b/Samidare-iOS/ApplicationModel/Model/Firebase/FirebaseAnalyticsConfig.swift
@@ -1,0 +1,29 @@
+//
+//  FirebaseAnalyticsConfig.swift
+//  Samidare-iOS
+//
+//  Created by 杉岡成哉 on 2022/09/14.
+//
+
+import Firebase
+
+struct FirebaseAnalyticsConfig {
+    enum EventType: String {
+        case start = "game_start"
+        case next = "question_next"
+        case stop = "game_stop"
+        case list = "question_list"
+        case addQuestionGroup = "add_question_group"
+        case addQuestion = "add_question"
+        case deleteQuestionGroup = "delete_question_group"
+    }
+    
+    static func sendEventLog(eventType: EventType) {
+        Analytics.logEvent(eventType.rawValue, parameters: nil)
+    }
+    
+    static func sendScreenViewLog(screenName: String) {
+        Analytics.logEvent(AnalyticsEventScreenView, parameters: [AnalyticsParameterScreenName: screenName,
+                                                                 AnalyticsParameterScreenClass: screenName])
+    }
+}

--- a/Samidare-iOS/ApplicationModel/Model/Firebase/FirebaseAnalyticsConfig.swift
+++ b/Samidare-iOS/ApplicationModel/Model/Firebase/FirebaseAnalyticsConfig.swift
@@ -16,6 +16,11 @@ struct FirebaseAnalyticsConfig {
         case addQuestionGroup = "add_question_group"
         case addQuestion = "add_question"
         case deleteQuestionGroup = "delete_question_group"
+        case deleteQuestion = "delete_question"
+        case editQuestionGroupName = "edit_question_group_name"
+        case updateQuestion = "update_question"
+        case changeQuestionGroup = "change_question_group"
+        case changeQuestionTime = "change_question_time"
     }
     
     static func sendEventLog(eventType: EventType) {

--- a/Samidare-iOS/ApplicationModel/Model/Firebase/FirebaseAnalyticsConfig.swift
+++ b/Samidare-iOS/ApplicationModel/Model/Firebase/FirebaseAnalyticsConfig.swift
@@ -23,7 +23,8 @@ struct FirebaseAnalyticsConfig {
     }
     
     static func sendScreenViewLog(screenName: String) {
-        Analytics.logEvent(AnalyticsEventScreenView, parameters: [AnalyticsParameterScreenName: screenName,
-                                                                 AnalyticsParameterScreenClass: screenName])
+        Analytics.logEvent(AnalyticsEventScreenView, parameters: [
+            AnalyticsParameterScreenName: screenName,
+            AnalyticsParameterScreenClass: screenName])
     }
 }

--- a/Samidare-iOS/ConfigModule/ConfigView.swift
+++ b/Samidare-iOS/ConfigModule/ConfigView.swift
@@ -48,6 +48,7 @@ struct ConfigView<Repository: AppConfigRepositoryProtocol>: View {
         }
         .onAppear {
             presenter.getAppConfig()
+            FirebaseAnalyticsConfig.sendScreenViewLog(screenName: "\(ConfigView.self)")
         }
         .sheet(isPresented: $presenter.shouldShowSafariView) {
             if let string = presenter.selectedExternalLinkType?.url,

--- a/Samidare-iOS/GroupAdditionModule/GroupAdditionPresenter.swift
+++ b/Samidare-iOS/GroupAdditionModule/GroupAdditionPresenter.swift
@@ -29,6 +29,7 @@ class GroupAdditionPresenter<Repository: QuestionGroupRepositoryProtocol>: Obser
     }
     
     func addQuestionGroup() {
+        FirebaseAnalyticsConfig.sendEventLog(eventType: .addQuestionGroup)
         do {
             let questionGroup = QuestionGroup(name: addAlertText)
             try interactor.add(questionGroup)
@@ -42,6 +43,7 @@ class GroupAdditionPresenter<Repository: QuestionGroupRepositoryProtocol>: Obser
         guard let editQuestionGroup = editQuestionGroup else {
             return
         }
+        FirebaseAnalyticsConfig.sendEventLog(eventType: .editQuestionGroupName)
         do {
             try interactor.add(.init(id: editQuestionGroup.id, name: editAlertText))
             groups = interactor.getQuestionGroup()
@@ -61,6 +63,7 @@ class GroupAdditionPresenter<Repository: QuestionGroupRepositoryProtocol>: Obser
     }
 
     func delete(_ group: QuestionGroup) {
+        FirebaseAnalyticsConfig.sendEventLog(eventType: .deleteQuestionGroup)
         do {
             try interactor.delete(group)
             groups = interactor.getQuestionGroup()

--- a/Samidare-iOS/GroupAdditionModule/GroupAdditionView.swift
+++ b/Samidare-iOS/GroupAdditionModule/GroupAdditionView.swift
@@ -79,6 +79,9 @@ struct GroupAdditionView<Repository: QuestionGroupRepositoryProtocol>: View {
             .alert(isPresented: $presenter.isShowingQuestionGroupUniqueErrorAlert) {
                 Alert(title: Text(""), message: Text(L10n.Error.Question.Group.unique))
             }
+            .onAppear {
+                FirebaseAnalyticsConfig.sendScreenViewLog(screenName: "\(GroupAdditionView.self)")
+            }
         }
     }
 }

--- a/Samidare-iOS/QuestionAdditionModule/QuestionAdditionPresenter.swift
+++ b/Samidare-iOS/QuestionAdditionModule/QuestionAdditionPresenter.swift
@@ -30,6 +30,7 @@ class QuestionAdditionPresenter<Repository: QuestionRepositoryProtocol>: Observa
     }
     
     func addQuestion() {
+        FirebaseAnalyticsConfig.sendEventLog(eventType: .addQuestion)
         do {
             let question = Question(body: addQuestionBody, group: group)
             try interactor.add(question)
@@ -40,6 +41,7 @@ class QuestionAdditionPresenter<Repository: QuestionRepositoryProtocol>: Observa
     }
     
     func updateQuestion() {
+        FirebaseAnalyticsConfig.sendEventLog(eventType: .updateQuestion)
         do {
             guard let questionToUpdate = questionToUpdate else {
                 return
@@ -57,6 +59,7 @@ class QuestionAdditionPresenter<Repository: QuestionRepositoryProtocol>: Observa
     }
     
     func deleteQuestion(on index: IndexSet) {
+        FirebaseAnalyticsConfig.sendEventLog(eventType: .deleteQuestion)
         guard let index = index.first, let question = questions?[safe: index] else { return }
         do {
             try interactor.delete(question)

--- a/Samidare-iOS/QuestionAdditionModule/QuestionAdditionView.swift
+++ b/Samidare-iOS/QuestionAdditionModule/QuestionAdditionView.swift
@@ -61,6 +61,9 @@ struct QuestionAdditionView<Repository: QuestionRepositoryProtocol>: View {
                     })
                 }
             }
+            .onAppear {
+                FirebaseAnalyticsConfig.sendScreenViewLog(screenName: "\(QuestionAdditionView.self)")
+            }
         }
     }
 }

--- a/Samidare-iOS/QuestionListModule/QuestionListView.swift
+++ b/Samidare-iOS/QuestionListModule/QuestionListView.swift
@@ -35,6 +35,9 @@ struct QuestionListView<Repository: QuestionRepositoryProtocol>: View {
                     })
                 }
             }
+            .onAppear {
+                FirebaseAnalyticsConfig.sendScreenViewLog(screenName: "\(QuestionListView.self)")
+            }
         }
     }
 }

--- a/Samidare-iOS/QuestionModule/QuestionPresenter.swift
+++ b/Samidare-iOS/QuestionModule/QuestionPresenter.swift
@@ -252,6 +252,7 @@ class QuestionPresenter<QuestionRepository: QuestionRepositoryProtocol, AppConfi
             playTimer?.invalidate()
         }
         status = status == .play ? .stopPlaying : .stopReadying
+        FirebaseAnalyticsConfig.sendEventLog(eventType: .stop)
     }
     
     // MARK: - helper
@@ -273,10 +274,12 @@ class QuestionPresenter<QuestionRepository: QuestionRepositoryProtocol, AppConfi
         }
         selectIndex += 1
         setDefaultNowPlayTime()
+        FirebaseAnalyticsConfig.sendEventLog(eventType: .next)
     }
     
     private func goToListView() {
         shouldShowQuestionList = true
+        FirebaseAnalyticsConfig.sendEventLog(eventType: .list)
     }
     
     private func resetPlayConfig() {

--- a/Samidare-iOS/QuestionModule/QuestionPresenter.swift
+++ b/Samidare-iOS/QuestionModule/QuestionPresenter.swift
@@ -131,7 +131,10 @@ class QuestionPresenter<QuestionRepository: QuestionRepositoryProtocol, AppConfi
     
     func primaryButtonAction() {
         switch status {
-        case .standBy, .stopReadying:
+        case .standBy:
+            FirebaseAnalyticsConfig.sendEventLog(eventType: .start)
+            start()
+        case .stopReadying:
             start()
         case .stopPlaying:
             play()

--- a/Samidare-iOS/QuestionModule/QuestionView.swift
+++ b/Samidare-iOS/QuestionModule/QuestionView.swift
@@ -58,6 +58,7 @@ struct QuestionView<QuestionRepository: QuestionRepositoryProtocol, AppConfigRep
         .padding(.horizontal, 16)
         .onAppear {
             presenter.viewWillApper()
+            FirebaseAnalyticsConfig.sendScreenViewLog(screenName: "\(QuestionView.self)")
         }
         .sheet(isPresented: $presenter.shouldShowQuestionList) {
             QuestionListView<QuestionRepositoryImpl>(presenter: .init(interactor: .init(), group: presenter.questionGroupName))

--- a/project.yml
+++ b/project.yml
@@ -140,12 +140,6 @@ targets:
         outputFiles:
           - $(SRCROOT)/Samidare-iOS/Generated/Localized.swift
           - $(SRCROOT)/Samidare-iOS/Generated/Images.swift
-      - name: FirebaseCrashlytics
-        script: |
-          ${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run
-        inputFiles:
-          - ${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${TARGET_NAME}
-          - $(SRCROOT)/$(BUILT_PRODUCTS_DIR)/$(INFOPLIST_PATH)
     postCompileScripts:
       - name: Firebase
         script: |
@@ -179,6 +173,13 @@ targets:
           fi
         outputFiles:
           - ${PROJECT_DIR}/Samidare-iOSTests/MockResults.swift
+    postbuildScripts:
+      - name: FirebaseCrashlytics
+        script: |
+          ${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run
+        inputFiles:
+          - ${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${TARGET_NAME}
+          - $(SRCROOT)/$(BUILT_PRODUCTS_DIR)/$(INFOPLIST_PATH)
   Samidare-iOSTests:
     info:
       path: Samidare-iOSTests/Info.plist

--- a/project.yml
+++ b/project.yml
@@ -140,6 +140,12 @@ targets:
         outputFiles:
           - $(SRCROOT)/Samidare-iOS/Generated/Localized.swift
           - $(SRCROOT)/Samidare-iOS/Generated/Images.swift
+      - name: FirebaseCrashlytics
+        script: |
+          ${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run
+        inputFiles:
+          - ${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${TARGET_NAME}
+          - $(SRCROOT)/$(BUILT_PRODUCTS_DIR)/$(INFOPLIST_PATH)
     postCompileScripts:
       - name: Firebase
         script: |


### PR DESCRIPTION
## 概要
SSIA

## issue
fix #42 

## 導入方法
### Crashlytics
[公式](https://firebase.google.com/docs/crashlytics/get-started?hl=ja&platform=ios)と[これ](https://qiita.com/mtkmr/items/82436a39b1432955931e)を見て実装
- SDKの導入(既に対応済みだったのでこのPRでは未対応)
- dSYM ファイルを自動的にアップロードするように Xcode を設定する
    - scriptをXcodeに記載
##### 注意点
DWARF with dSYM fileに変更する処理だがdebug環境でcrashlyticsを取る必要がないのでdebug環境では行わない。行うと大量のwarningが出るので。

### Analytics
ログを送る処理を記載しただけ
