### PR TITLE
QuestionPresenter周りをリファクタリング

### DIFF
--- a/Samidare/QuestionModule/QuestionInteractor.swift
+++ b/Samidare/QuestionModule/QuestionInteractor.swift
@@ -8,11 +8,38 @@
 import Foundation
 
 class QuestionInteractor<QuestionRepository: QuestionRepositoryProtocol, AppConfigRepository: AppConfigRepositoryProtocol> {
-
-    func getQuestion(from index: Int) -> Question? {
+    
+    private func questions() -> [Question] {
         let group = AppConfigRepository.get().questionGroupName
-        let questions = QuestionRepository.getQuestions(of: group)
-        return questions[safe: index]
+        return QuestionRepository.getQuestions(of: group)
+    }
+    
+    /*
+     parameters:    次の質問を取得したい質問。
+     return:        次の質問。※parametersがnilの時は最初の質問を返す
+     */
+    func nextQuestion(for question: Question) -> Question? {
+        let questions = questions()
+        guard let questionOfIndex = getIndex(of: question) else {
+            return questions.first
+        }
+        return questions[safe: questionOfIndex + 1]
+    }
+    
+    func firstQuestion() -> Question? {
+        questions().first
+    }
+    
+    func lastQuestion() -> Question? {
+        questions().last
+    }
+    
+    func shouldShowQuestion(question: Question?) -> Bool {
+        question != nil
+    }
+    
+    func getIndex(of question: Question) -> Int? {
+        questions().firstIndex(of: question)
     }
     
     func getTotalQuestionCount() -> Int {

--- a/Samidare/QuestionModule/QuestionInteractor.swift
+++ b/Samidare/QuestionModule/QuestionInteractor.swift
@@ -34,10 +34,6 @@ class QuestionInteractor<QuestionRepository: QuestionRepositoryProtocol, AppConf
         questions().last
     }
     
-    func shouldShowQuestion(question: Question?) -> Bool {
-        question != nil
-    }
-    
     func getIndex(of question: Question) -> Int? {
         questions().firstIndex(of: question)
     }

--- a/Samidare/QuestionModule/QuestionPresenter.swift
+++ b/Samidare/QuestionModule/QuestionPresenter.swift
@@ -87,7 +87,9 @@ class QuestionPresenter<QuestionRepository: QuestionRepositoryProtocol, AppConfi
         }
     }
     
-    private(set) var questionGroupName: String
+    var questionGroupName: String {
+        interactor.questionGroup()
+    }
 
     var shouldShowQuestionCount: Bool {
         status != .standBy && status != .ready && status != .stopReadying
@@ -112,7 +114,6 @@ class QuestionPresenter<QuestionRepository: QuestionRepositoryProtocol, AppConfi
     init(interactor: QuestionInteractor<QuestionRepository, AppConfigRepository>, timerProvider: Timer.Type = Timer.self) {
         self.interactor = interactor
         self.timerProvider = timerProvider
-        self.questionGroupName = interactor.questionGroup()
     }
 
     // MARK: - Life Cycle
@@ -121,7 +122,6 @@ class QuestionPresenter<QuestionRepository: QuestionRepositoryProtocol, AppConfi
         setDefaultNowPlayTime()
         setTotalPlayTime()
         setTotalQuestionCount()
-        setQuestionGroup()
         setQuestion()
     }
     
@@ -168,10 +168,6 @@ class QuestionPresenter<QuestionRepository: QuestionRepositoryProtocol, AppConfi
 
     private func setTotalQuestionCount() {
         totalQuestionCount = interactor.getTotalQuestionCount()
-    }
-    
-    private func setQuestionGroup() {
-        questionGroupName = interactor.questionGroup()
     }
     
     private func setQuestionCountText() {

--- a/Samidare/QuestionModule/QuestionPresenter.swift
+++ b/Samidare/QuestionModule/QuestionPresenter.swift
@@ -83,10 +83,8 @@ class QuestionPresenter<QuestionRepository: QuestionRepositoryProtocol, AppConfi
             setQuestionCountText()
         }
     }
-    private var totalQuestionCount = 0 {
-        didSet {
-            setQuestionCountText()
-        }
+    private var totalQuestionCount: Int {
+        interactor.getTotalQuestionCount()
     }
     
     var questionGroupName: String {
@@ -122,7 +120,7 @@ class QuestionPresenter<QuestionRepository: QuestionRepositoryProtocol, AppConfi
     
     func viewWillApper() {
         setDefaultNowPlayTime()
-        setTotalQuestionCount()
+        setQuestionCountText()
         setQuestion()
     }
     
@@ -161,10 +159,6 @@ class QuestionPresenter<QuestionRepository: QuestionRepositoryProtocol, AppConfi
     
     private func setDefaultNowPlayTime() {
         nowPlayTime = Double(interactor.getTime())
-    }
-
-    private func setTotalQuestionCount() {
-        totalQuestionCount = interactor.getTotalQuestionCount()
     }
     
     private func setQuestionCountText() {

--- a/Samidare/QuestionModule/QuestionPresenter.swift
+++ b/Samidare/QuestionModule/QuestionPresenter.swift
@@ -72,7 +72,9 @@ class QuestionPresenter<QuestionRepository: QuestionRepositoryProtocol, AppConfi
     private var playTimer: Timer?
     private var countDownTimer: Timer?
     // トータルのゲーム時間
-    private var totalPlayTime: Int = 0
+    private var totalPlayTime: Int {
+        interactor.getTime()
+    }
     // 経過時間(totalPlayTimeからデクリメントで計算)
     private var nowPlayTime = 0.0
     private var selectIndex = 0 {
@@ -120,7 +122,6 @@ class QuestionPresenter<QuestionRepository: QuestionRepositoryProtocol, AppConfi
     
     func viewWillApper() {
         setDefaultNowPlayTime()
-        setTotalPlayTime()
         setTotalQuestionCount()
         setQuestion()
     }
@@ -160,10 +161,6 @@ class QuestionPresenter<QuestionRepository: QuestionRepositoryProtocol, AppConfi
     
     private func setDefaultNowPlayTime() {
         nowPlayTime = Double(interactor.getTime())
-    }
-
-    private func setTotalPlayTime() {
-        totalPlayTime = interactor.getTime()
     }
 
     private func setTotalQuestionCount() {

--- a/Samidare/QuestionModule/QuestionPresenter.swift
+++ b/Samidare/QuestionModule/QuestionPresenter.swift
@@ -105,9 +105,9 @@ class QuestionPresenter<QuestionRepository: QuestionRepositoryProtocol, AppConfi
     @Published private(set) var status: Status = .standBy
     // プログレスバーの位置
     @Published private(set) var duration: CGFloat = 1.0
-    @Published var shouldShowQuestionList = false
     // 開始前のカウントダウン
     @Published private(set) var nowCountDownTime = readyCountDownTime
+    @Published var shouldShowQuestionList = false
     
     init(interactor: QuestionInteractor<QuestionRepository, AppConfigRepository>, timerProvider: Timer.Type = Timer.self) {
         self.interactor = interactor

--- a/Samidare/QuestionModule/QuestionPresenter.swift
+++ b/Samidare/QuestionModule/QuestionPresenter.swift
@@ -91,6 +91,10 @@ class QuestionPresenter<QuestionRepository: QuestionRepositoryProtocol, AppConfi
         totalQuestionCount > selectIndex
     }
     
+    private var isQuestionTimeout: Bool {
+        nowPlayTime < 0
+    }
+    
     var questionGroupName: String {
         interactor.questionGroup()
     }
@@ -203,8 +207,7 @@ class QuestionPresenter<QuestionRepository: QuestionRepositoryProtocol, AppConfi
             if self.hasNextQuestion {
                 self.nowPlayTime -= 0.1
                 self.duration = CGFloat(self.nowPlayTime) / CGFloat(self.totalPlayTime)
-                // 1つの質問を表示する時間を過ぎたかどうか
-                if self.nowPlayTime < 0 {
+                if self.isQuestionTimeout {
                     self.next()
                 }
             // 全ての質問を表示し終わった

--- a/Samidare/QuestionModule/QuestionPresenter.swift
+++ b/Samidare/QuestionModule/QuestionPresenter.swift
@@ -107,7 +107,7 @@ class QuestionPresenter<QuestionRepository: QuestionRepositoryProtocol, AppConfi
     @Published private(set) var duration: CGFloat = 1.0
     @Published var shouldShowQuestionList = false
     // 開始前のカウントダウン
-    @Published var nowCountDownTime = readyCountDownTime
+    @Published private(set) var nowCountDownTime = readyCountDownTime
     
     init(interactor: QuestionInteractor<QuestionRepository, AppConfigRepository>, timerProvider: Timer.Type = Timer.self) {
         self.interactor = interactor

--- a/Samidare/QuestionModule/QuestionPresenter.swift
+++ b/Samidare/QuestionModule/QuestionPresenter.swift
@@ -85,6 +85,10 @@ class QuestionPresenter<QuestionRepository: QuestionRepositoryProtocol, AppConfi
         nowPlayTime < 0
     }
     
+    private var shouldShowQuestion: Bool {
+        question != nil
+    }
+    
     var questionGroupName: String {
         interactor.questionGroup()
     }
@@ -202,7 +206,7 @@ class QuestionPresenter<QuestionRepository: QuestionRepositoryProtocol, AppConfi
         playTimer?.invalidate()
         playTimer = timerProvider.scheduledTimer(withTimeInterval: 0.1, repeats: true) { [weak self] _ in
             guard let self = self else { return }
-            if self.interactor.shouldShowQuestion(question: self.question) {
+            if self.shouldShowQuestion {
                 self.nowPlayTime -= 0.1
                 self.duration = CGFloat(self.nowPlayTime) / CGFloat(self.totalPlayTime)
                 if self.isQuestionTimeout {

--- a/Samidare/QuestionModule/QuestionPresenter.swift
+++ b/Samidare/QuestionModule/QuestionPresenter.swift
@@ -87,6 +87,10 @@ class QuestionPresenter<QuestionRepository: QuestionRepositoryProtocol, AppConfi
         interactor.getTotalQuestionCount()
     }
     
+    private var hasNextQuestion: Bool {
+        totalQuestionCount > selectIndex
+    }
+    
     var questionGroupName: String {
         interactor.questionGroup()
     }
@@ -196,8 +200,7 @@ class QuestionPresenter<QuestionRepository: QuestionRepositoryProtocol, AppConfi
         playTimer?.invalidate()
         playTimer = timerProvider.scheduledTimer(withTimeInterval: 0.1, repeats: true) { [weak self] _ in
             guard let self = self else { return }
-            // 最後の質問ではないかどうか
-            if self.totalQuestionCount > self.selectIndex {
+            if self.hasNextQuestion {
                 self.nowPlayTime -= 0.1
                 self.duration = CGFloat(self.nowPlayTime) / CGFloat(self.totalPlayTime)
                 // 1つの質問を表示する時間を過ぎたかどうか

--- a/Samidare/QuestionModule/QuestionView.swift
+++ b/Samidare/QuestionModule/QuestionView.swift
@@ -29,7 +29,7 @@ struct QuestionView<QuestionRepository: QuestionRepositoryProtocol, AppConfigRep
                                      gradationTop: presenter.status.gradationTop,
                                      gradationBottom: presenter.status.gradationBottom)
                     if presenter.isReady {
-                        ReadyTexts(countDownTimeText: $presenter.nowCountDownTime)
+                        ReadyTexts(countDownTimeText: presenter.nowCountDownTime.description)
                     }
                 }
                 .frame(height: 220)
@@ -67,10 +67,10 @@ struct QuestionView<QuestionRepository: QuestionRepositoryProtocol, AppConfigRep
 }
 
 private struct ReadyTexts: View {
-    let countDownTimeText: Binding<Int>
+    let countDownTimeText: String
     var body: some View {
         VStack(alignment: .center) {
-            Text(String(countDownTimeText.wrappedValue))
+            Text(countDownTimeText)
                 .font(.system(size: 150))
                 .fontWeight(.bold)
                 .foregroundColor(.white)

--- a/SamidareTests/Question/QuestionInteractorTests.swift
+++ b/SamidareTests/Question/QuestionInteractorTests.swift
@@ -10,7 +10,9 @@ import XCTest
 
 class QuestionInteractorTests: XCTestCase {
     private var interactor: QuestionInteractor<QuestionRepositoryProtocolMock, AppConfigRepositoryProtocolMock>!
-    private let question = Question(body: "好きな色は", group: .init(name: "default"))
+    private let firstQuestion = Question(body: "好きな色は", group: .init(name: "default"))
+    private let secondQuestion = Question(body: "将来の夢は", group: .init(name: "default"))
+    private let lastQuestion = Question(body: "好きな食べ物は", group: .init(name: "default"))
     
     override func setUp() {
         super.setUp()
@@ -20,23 +22,53 @@ class QuestionInteractorTests: XCTestCase {
         }
         QuestionRepositoryProtocolMock.getQuestionsHandler = { _ in
             [
-                self.question,
-                .init(body: "将来の夢は", group: .init(name: "default"))
+                self.firstQuestion,
+                self.secondQuestion,
+                self.lastQuestion
             ]
         }
         interactor = .init()
     }
     
-    func testGetQuestion() {
-        // 取得成功
-        XCTAssertEqual(interactor.getQuestion(from: 0)!, question)
+    func testNextQuestion() {
+        // 存在しない質問
+        // 存在しない質問の場合は最初の質問を返す
+        XCTAssertEqual(interactor.nextQuestion(for: .init(body: "存在しない質問", group: .init(name: "default"))), firstQuestion)
         
-        // index外
-        XCTAssertNil(interactor.getQuestion(from: -1))
+        // 次の質問を取得
+        XCTAssertEqual(interactor.nextQuestion(for: firstQuestion), secondQuestion)
+        
+        // 最後の質問
+        XCTAssertNil(interactor.nextQuestion(for: lastQuestion))
+    }
+    
+    func testFirstQuestion() {
+        XCTAssertEqual(interactor.firstQuestion(), firstQuestion)
+        
+        QuestionRepositoryProtocolMock.getQuestionsHandler = { _ in
+            []
+        }
+        XCTAssertNil(interactor.firstQuestion())
+    }
+    
+    func testLastQuestion() {
+        XCTAssertEqual(interactor.lastQuestion(), lastQuestion)
+        
+        QuestionRepositoryProtocolMock.getQuestionsHandler = { _ in
+            []
+        }
+        XCTAssertNil(interactor.lastQuestion())
+    }
+    
+    func testGetIndex() {
+        XCTAssertEqual(interactor.getIndex(of: firstQuestion), 0)
+        XCTAssertEqual(interactor.getIndex(of: secondQuestion), 1)
+        XCTAssertEqual(interactor.getIndex(of: lastQuestion), 2)
+        XCTAssertNil(interactor.getIndex(of: .init(body: "存在しない質問", group: .init(name: "default"))))
     }
     
     func testGetTotalQuestionCount() {
-        XCTAssertEqual(interactor.getTotalQuestionCount(), 2)
+        XCTAssertEqual(interactor.getTotalQuestionCount(), 3)
     }
     
     func testGetTime() {

--- a/SamidareTests/Question/QuestionPresenterTests.swift
+++ b/SamidareTests/Question/QuestionPresenterTests.swift
@@ -98,7 +98,7 @@ class QuestionPresenterTests: XCTestCase {
         wait(for: [expOverTime], timeout: 1.0)
         /// 質問時間経過で次の質問に行っているか確認
         XCTAssertNil(presenter.question)
-        XCTAssertEqual(presenter.questionCountText, "2/1")
+        XCTAssertEqual(presenter.questionCountText, "")
         
         // ゲーム完了
         let expDone = expectation(description: "ゲーム完了")


### PR DESCRIPTION
## 概要
QuestionPresenterとQuestionInteractorをリファクタリング

## 作業内容
- QuestionInteractor
    - indexで管理をするのではなく、Interactorで次の質問、最初の質問、最後の質問、質問を表示すべきか、質問のindexを返すように修正
- QuestionPresenter
    - nowCountDownTimeがvarである必要がないのでprivate(set)に修正
    - totalPlayTime、totalQuestionCount、questionGroupNameをComputed propertyに修正してinteractorから取得するように修正
    - isQuestionTimeout、shouldShowQuestionをプロパティとして定義して名前を与えた
    - index管理ではなくinteractorから値を取得するように修正